### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,10 +10,12 @@ SRT (SecurityRobot Tool) is a historical Windows desktop utility built with **Ob
 srt/
 ├── .github/
 │   └── copilot-instructions.md  # This file
+├── .gitignore                    # VCS ignore rules for Delphi build artifacts
 ├── SRT.dpr                       # Delphi project file – application entry point, creates TFrmPrincipal
 ├── SRT.res                       # Compiled application resource file (icons)
 ├── USRT.pas                      # Main unit – ARP-based router discovery, UPnP port mapping, hidden subprocess execution
 ├── USRT.dfm                      # Main form layout – Buttons, TMemo log, TSpinEdit for port selection
+├── CHANGELOG.md                  # Project changelog (Keep a Changelog format)
 ├── CONTRIBUTING.md               # Historical build information
 ├── LICENSE                       # MIT License
 └── README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` repository structure to include `.gitignore` and `CHANGELOG.md`
+
 ### Removed
 
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.